### PR TITLE
[DISCUSSION] Add Preact via preact-compat

### DIFF
--- a/link-user/config-overrides.js
+++ b/link-user/config-overrides.js
@@ -1,0 +1,7 @@
+const rewirePreact = require("react-app-rewire-preact")
+
+/* config-overrides.js */
+module.exports = function override(config, env) {
+  config = rewirePreact(config, env)
+  return config
+}

--- a/link-user/package-lock.json
+++ b/link-user/package-lock.json
@@ -4992,6 +4992,14 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
       "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
     },
+    "immutability-helper": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.7.1.tgz",
+      "integrity": "sha512-6uhvN9F1TRPtirUV3b7MIeY34h+U2hFR5hyK6jaWOvT36BNXYCx2tGujZhx/41fzUta/VNmK47scDhohTFYRDw==",
+      "requires": {
+        "invariant": "^2.2.0"
+      }
+    },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
@@ -8502,6 +8510,43 @@
         }
       }
     },
+    "preact": {
+      "version": "8.2.9",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.9.tgz",
+      "integrity": "sha512-ThuGXBmJS3VsT+jIP+eQufD3L8pRw/PY3FoCys6O9Pu6aF12Pn9zAJDX99TfwRAFOCEKm/P0lwiPTbqKMJp0fA=="
+    },
+    "preact-compat": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/preact-compat/-/preact-compat-3.18.0.tgz",
+      "integrity": "sha512-4ygl49bkMyPEx2ZwkNDh2AhUa62g2lwJYIsQU4IR5zW4d4QIyucmZFr/hu2+aeFP4YVR8nVZg1KWMETpP32UkA==",
+      "requires": {
+        "immutability-helper": "^2.1.2",
+        "preact-render-to-string": "^3.6.0",
+        "preact-transition-group": "^1.1.0",
+        "prop-types": "^15.5.8",
+        "standalone-react-addons-pure-render-mixin": "^0.1.1"
+      }
+    },
+    "preact-render-to-string": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-3.7.0.tgz",
+      "integrity": "sha1-fbQXdFS8ATleDQHWrAe8XoOOMe4=",
+      "requires": {
+        "pretty-format": "^3.5.1"
+      },
+      "dependencies": {
+        "pretty-format": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+          "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
+        }
+      }
+    },
+    "preact-transition-group": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/preact-transition-group/-/preact-transition-group-1.1.1.tgz",
+      "integrity": "sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -8766,6 +8811,24 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.0"
+      }
+    },
+    "react-app-rewire-preact": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-app-rewire-preact/-/react-app-rewire-preact-1.0.1.tgz",
+      "integrity": "sha1-TU0XNghb0OxKRvGMHlpado/4urs=",
+      "requires": {
+        "preact": "^8.1.0",
+        "preact-compat": "^3.16.0"
+      }
+    },
+    "react-app-rewired": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-1.5.2.tgz",
+      "integrity": "sha512-/cbaFBaSYvCcj2BnolCh2Cx0J8QwFECg5RssXFPckhdzC9iEb5BKJGqt71ZTOF35gv6ebo4CPKJR4nZajzW4Sw==",
+      "requires": {
+        "cross-spawn": "^5.1.0",
+        "dotenv": "^4.0.0"
       }
     },
     "react-dev-utils": {
@@ -9816,6 +9879,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "standalone-react-addons-pure-render-mixin": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz",
+      "integrity": "sha1-PHQJ9MecQN6axyxhbPZ5qZTzdVE="
     },
     "static-extend": {
       "version": "0.1.2",

--- a/link-user/package.json
+++ b/link-user/package.json
@@ -3,14 +3,18 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "preact": "^8.2.9",
+    "preact-compat": "^3.18.0",
     "react": "^16.4.0",
+    "react-app-rewire-preact": "^1.0.1",
+    "react-app-rewired": "^1.5.2",
     "react-dom": "^16.4.0",
     "react-scripts": "1.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test --env=jsdom",
+    "eject": "react-app-rewired eject"
   }
 }


### PR DESCRIPTION
This PR is one way to execute the order decreed in [ADR #10](https://github.com/zendesk/link_platform/blob/jpandl/preact-switch/doc/architecture/decisions/0010-use-preact-for-the-end-user-website.md). 

The `link-user` app was switched from React to preact using `preact-compat`.

## Bundle Size Differences
#### React
![image](https://user-images.githubusercontent.com/11040668/42912185-e73fef86-8aa2-11e8-8a08-7ede22cc3e40.png)

**`main.js`: 36.71 KB**

#### Preact via `preact-compat`
![image](https://user-images.githubusercontent.com/11040668/42912132-b5ee004e-8aa2-11e8-8a76-5e30d31bdc49.png)
**`main.js`: 13.09 KB**

#### Summary
Using `preact-compat` reduces our bundle size by **23.62 KB**


## Package.json Changes

- `"preact": "^8.2.9"` - See [ADR #10](https://github.com/zendesk/link_platform/blob/jpandl/preact-switch/doc/architecture/decisions/0010-use-preact-for-the-end-user-website.md) for details [(view on npm)](https://www.npmjs.com/package/preact)
- `"preact-compat": "^3.18.0"` - Makes all React-based modules work with Preact without any code changes [(view on npm)](https://www.npmjs.com/package/preact-compat)
- `"react-app-rewired": "^1.5.2"` - Allows us to tweak the webpack configs of CRA without ejecting [(view on npm)](Tweak the create-react-app webpack config(s) without using 'eject)
- `"react-app-rewire-preact": "^1.0.1"` - Allows us to stick with CRA and use preact [(view on npm)](https://www.npmjs.com/package/react-app-rewire-preact)



## TODO
- [ ] Check out how using preact without `preact-compat` affects our bundle size and determine whether or not it is worth it. Link PR here