### PR TITLE
Change ADR 10 status to Accepted

### DIFF
--- a/doc/architecture/decisions/0010-use-preact-for-the-end-user-website.md
+++ b/doc/architecture/decisions/0010-use-preact-for-the-end-user-website.md
@@ -4,7 +4,7 @@ Date: 2018-06-13
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 


### PR DESCRIPTION
# Description
This PR updates the status of *ADR 10:Use Preact for the End-User Application* to "Accepted".

# Preact vs preact-compat
There are a couple of libraries from `linksf` that rely on React (and thus would need `preact-compat`):
- `react-google-autocomplete` (https://github.com/ErrorPro/react-google-autocomplete)
- `react-google-maps` (https://github.com/tomchentw/react-google-maps)

Here are a few Preact compatible replacements/ alternative options for us:

#### `react-google-autocomplete`
1. Use https://github.com/ubilabs/react-geosuggest
Simple autocomplete which utilizes the Google Maps Places API. Similar to `react-google-autocomplete` but includes support for Preact out of the box

2. Implement the lib ourselves and remove the React dependency.
This would be very simple. The lib is only 113 lines and enabling Preact support would be as easy as switching the ~10 lines of code that depend on React to their Preact equivalents.


#### `react-google-maps`

1. https://github.com/alacroix/google-map-preact 
Just a fork of `react-google-maps` that replaces React code with its Preact equivalent


### Summary
Our usages of these libraries are very simple and both have adequate options for replacement. Using Preact without `preact-compat` seems like the way to go to me.
 