### PR TITLE
Allow admin creation

### DIFF
--- a/link-api/app/controllers/admins/registrations_controller.rb
+++ b/link-api/app/controllers/admins/registrations_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Admins
+  class RegistrationsController < DeviseTokenAuth::RegistrationsController
+    protected
+
+    def build_resource
+      super
+
+      @resource.link_instance = current_link_instance
+    end
+  end
+end

--- a/link-api/config/application.rb
+++ b/link-api/config/application.rb
@@ -39,5 +39,9 @@ module LinkApi
       require 'dotenv'
       Dotenv.load
     end
+
+    # Load middleware required for Omniauth
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
   end
 end

--- a/link-api/config/routes.rb
+++ b/link-api/config/routes.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'Admin', at: 'auth'
+  mount_devise_token_auth_for 'Admin', at: 'auth', controllers: {
+    registrations: 'admins/registrations'
+  }
 
   resources :link_instances
 

--- a/link-api/db/seeds.rb
+++ b/link-api/db/seeds.rb
@@ -119,3 +119,12 @@ Program.create!(
   organization_id: organization.id,
   link_instance_id: link_instance.id
 )
+
+Admin.create!(
+  email: "ga@linkplatform.com",
+  name: "Great Admin",
+  nickname: "Goodness Gracious Great Admin",
+  password: "link_platform",
+  link_instance_id: link_instance.id,
+  confirmed_at: Time.now
+)


### PR DESCRIPTION
In order to get admin creation working we need a few extra changes:

* Insert cookie middleware so Devise can carry its context through the call chain
* Exempt the Devise endpoints from our authentication and admin domain checks
* Permit names to be passed through for Admin requests
* Make some additions to the RegistrationsController so we can inject the new Admin's Link Instance

@zendesk/volunteer 