### PR TITLE
Update ADRs to explicitly specify strings id fields as UUID type

### DIFF
--- a/doc/architecture/decisions/0009-use-openreferal-api.md
+++ b/doc/architecture/decisions/0009-use-openreferal-api.md
@@ -6,7 +6,7 @@ Date: 2018-06-13
 
 Proposed
 
-Amended by [17. Use strings for all model id fields](0017-use-strings-for-all-model-id-fields.md)
+Amended by [17. Use string (uuid) for all model id fields](0017-use-strings-for-all-model-id-fields.md)
 
 ## Context
 
@@ -16,7 +16,7 @@ In this new project, we want to further support these efforts by exposing an ope
 
 ## Decision
 
-Adopt and extend the OpenReferal API and data structure.  
+Adopt and extend the OpenReferal API and data structure.
 We will extend the model to accommodate data that is specific to the link platform system.
 
 ## Consequences

--- a/doc/architecture/decisions/0017-use-strings-for-all-model-id-fields.md
+++ b/doc/architecture/decisions/0017-use-strings-for-all-model-id-fields.md
@@ -1,4 +1,4 @@
-# 17. Use strings for all model id fields
+# 17. Use string (uuid) for all model id fields
 
 Date: 2018-08-08
 
@@ -11,8 +11,8 @@ Amends [9. Use OpenReferal API](0009-use-openreferal-api.md)
 ## Context
 
 To enhance the ability to import data from any source that is compliant with the OpenReferral
-modle use strings for fields that are keys. 
- 
+modle use strings for fields that are keys.
+
 ## Decision
 
 Convert existing models to use strings instead of integers as the id fields and references.


### PR DESCRIPTION
//cc @zendesk/volunteer

This PR updates docs for string UUID fields

https://openreferral.readthedocs.io/en/latest/hsds/reference/#names-and-descriptions
