### PR TITLE
Hook up basic location detail page (end user)

### DIFF
--- a/link-user/src/components/Location.js
+++ b/link-user/src/components/Location.js
@@ -2,12 +2,12 @@ import { h } from 'preact';
 // import icons from '../../icons/css/fontello.css';
 import { createComponent } from 'preact-fela';
 
-import { relevantTaxonomies, getIcon } from '../../lib/taxonomies';
-import { capitalize } from '../../lib/stringHelpers';
+// import { relevantTaxonomies, getIcon } from '../../lib/taxonomies';
+// import { capitalize } from '../../lib/stringHelpers';
 
-import GoogleMap from './GoogleMap';
+// import GoogleMap from './GoogleMap';
 
-const nl2br = require('react-nl2br');
+// const nl2br = require('react-nl2br');
 
 const FlexContainer = createComponent(() => ({
 	display: 'flex'
@@ -399,18 +399,18 @@ const Location = props => {
 			<ParagraphTitle>Services</ParagraphTitle>
 			<Section>
 				<FlexContainer>
-					{relevantTaxonomies(services).map((taxonomy, index) => (
+					{/* {relevantTaxonomies(services).map((taxonomy, index) => (
 						<span key={`category-${index}`}>
 							<i className={`category-icon ${getIcon(taxonomy)}`} />
-							{capitalize(taxonomy)}
+							{taxonomy}
 						</span>
-					))}
+					))} */}
 				</FlexContainer>
 			</Section>
 			{location.physicalAddress && (
 				<MapInset>
 					<MapContainer>
-						<GoogleMap lat={location.latitude} long={location.longitude} />
+						{/* <GoogleMap lat={location.latitude} long={location.longitude} /> */}
 					</MapContainer>
 					<AddressText>{location.physicalAddress.address1}</AddressText>
 				</MapInset>
@@ -468,7 +468,7 @@ const Location = props => {
 							<NoteWrapperContainer>
 								<ServiceTitleText>{service.name}</ServiceTitleText>
 								<ServiceDescriptionText>
-									{nl2br(service.description)}
+									{service.description}
 								</ServiceDescriptionText>
 								<Schedule schedules={service.schedules} />
 							</NoteWrapperContainer>

--- a/link-user/src/pages/Location.js
+++ b/link-user/src/pages/Location.js
@@ -2,6 +2,16 @@
 import { h, Component } from 'preact';
 
 import Layout from '../components/Layout';
+import Location from '../components/Location';
+
+// TODO: remove mock data
+const organization = {
+	id: '1',
+    longDescription: 'This is such a great organization',
+    name: 'Great Org',
+    phones: [],
+    url: '',
+};
 
 class LocationPage extends Component {
 	constructor(props) {
@@ -19,7 +29,7 @@ class LocationPage extends Component {
 
 		return (
 			<Layout>
-                <p>{location.name}</p>
+                <Location location={location} organization={organization}></Location>
 			</Layout>
 		);
 	}


### PR DESCRIPTION
You can now navigate to a location's page which has some basic layout and whatnot. 
Need to resolve some missing utilities, coming soon.

Here is what is looks like now:
<img width="1650" alt="Screen Shot 2019-06-19 at 4 22 40 PM" src="https://user-images.githubusercontent.com/1217225/59807877-a1524900-92ae-11e9-812a-4899ebf16a1e.png">
