### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# This is a CODEOWNERS file. See https://help.github.com/articles/about-codeowners/
+
+# These owners will be the default owners for everything in the repo. Unless a 
+# later match takes precedence, @zendesk/volunteer will be requested for review 
+# when someone opens a pull request.
+*      @zendesk/volunteer


### PR DESCRIPTION
# Context

Just easier to default to pinging the `volunteer` team when a PR is opened. Feel free to add levels of specificity using the syntax described in this [link](https://help.github.com/en/articles/about-code-owners#codeowners-syntax)